### PR TITLE
Update cabal dependencies

### DIFF
--- a/yesod-worker.cabal
+++ b/yesod-worker.cabal
@@ -42,7 +42,7 @@ library
                       DeriveDataTypeable
 
   -- These constraints should work, but could likely be loosened
-  build-depends: base              >= 4.7   && < 4.8
+  build-depends: base              >= 4.6   && < 4.8
                , resourcet         >= 1.1.2.2
                , persistent        >= 2.1
                , yesod             >= 1.4
@@ -51,7 +51,7 @@ library
                , transformers-base >= 0.4.2
                , transformers      >= 0.4
                , monad-logger      >= 0.3
-               , monad-control     >= 0.3
+               , monad-control     >= 0.3   && < 1.0
                , template-haskell
                , fast-logger       >= 2.2
                , yesod-core        >= 1.4


### PR DESCRIPTION
- Loosen constrait on base a bit, many distros still only provide 4.6 (Fedora, Centos)
- monad-control >= 1.0 breaks the build so use earlier versions until code is updated for 1.0
