### PR TITLE
yesod-worker.cabal: add missing file to source tarball

### DIFF
--- a/yesod-worker.cabal
+++ b/yesod-worker.cabal
@@ -12,6 +12,7 @@ category:            Web
 build-type:          Simple
 -- extra-source-files:
 cabal-version:       >=1.10
+extra-source-files:  templates/home.hamlet
 
 library
   hs-source-dirs:      src


### PR DESCRIPTION
Noticed when tried to pull yesod-worker-0.1.0.0 in gentoo.
Failed as:

src/Yesod/Worker/Site.hs:38:28: error:
    • Exception when trying to run compile-time code:
        templates/home.hamlet: openFile: does not exist (No such file or directory)
      Code: whamletFile "templates/home.hamlet"
    • In the untyped splice: $(whamletFile "templates/home.hamlet")

Signed-off-by: Sergei Trofimovich siarheit@google.com
