### PR TITLE
Separate managers from processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.stack-work

--- a/src/Yesod/Worker.hs
+++ b/src/Yesod/Worker.hs
@@ -8,6 +8,7 @@ module Yesod.Worker
   , Workers
   , YesodWorker(..)
   , bootWorkers
+  , bootManagers
   , newWorkers
   , concurrency
   , register
@@ -31,6 +32,24 @@ instance YesodWorker master => YesodSubDispatch Workers (HandlerT master IO) whe
 
 newWorkers :: IO Workers
 newWorkers = Workers <$> newEmptyMVar <*> connect defaultConnectInfo
+
+
+bootManagers :: YesodWorker master => Configurator (HandlerT master IO) -> HandlerT master IO ()
+bootManagers declareJobs = void $ do
+  Workers{..} <- workers <$> getYesod
+
+  -- TODO: need to ensure we have enough connections in the pool to cover
+  -- - however many connections the client might need
+  conn <- liftIO $ connect (defaultConnectInfo { connectMaxConnections = 100 })
+  conf <- mkConf conn $ do
+    concurrency 10
+    middleware record
+    middleware retry
+    declareJobs
+
+  m <- mkManager conf
+  liftIO $ putMVar wManager m
+
 
 bootWorkers :: YesodWorker master => Configurator (HandlerT master IO) -> HandlerT master IO ()
 bootWorkers declareJobs = void $ do


### PR DESCRIPTION
This PR adds an initial version of separating the creation of managers from managers that will process jobs. It does this by creating a separate entry-point to `Yesod.Worker` that does not spawn the worker threads.

I've chosen to duplicate much of the code from `bootWorkers` as I imagine aspects changing over time, such as the number of client connections and the middleware (which might be entirely unnecessary on 'this end' of the queue).

I'd appreciate review of:

 - what is or isn't necessary in this startup process (i.e. can I safely drop the concurrency and middleware?).
 - naming (I'm not familiar with Sidekiq/Keenser, there may be a better option than `bootManagers`).
 - general approach (should managers and the Redis connections be separated at a deeper level so that managers aren't needed at all on the web server side? I haven't tried this because I'm not sure how much it might mess up the stats held in the managers)