### PR TITLE
Worker improvements

### DIFF
--- a/src/Yesod/Worker.hs
+++ b/src/Yesod/Worker.hs
@@ -14,6 +14,7 @@ module Yesod.Worker
   , enqueue
   , enqueueAt
   , enqueueIn
+  , workerRoute
   ) where
 
 import Keenser hiding (enqueue, enqueueAt, enqueueIn)
@@ -56,3 +57,5 @@ bootWorkers declareJobs = void $ do
 
 handleError :: e -> HandlerT site IO ()
 handleError _ = $(logError) "handleError"
+
+workerRoute = HomeR

--- a/src/Yesod/Worker/Site.hs
+++ b/src/Yesod/Worker/Site.hs
@@ -35,7 +35,7 @@ getHomeR = do
       ManagerStatus{..} <- checkStatus m wRedis
       let info    = Map.fromList sState
           get key = fromMaybe "" $ Map.lookup key info
-      lift $ defaultLayout $(whamletFile "templates/home.hamlet")
+      lift $ workerLayout $(whamletFile "templates/home.hamlet")
     _ -> do
       $(logError) "No manager running"
       return "No manager running"

--- a/src/Yesod/Worker/Types.hs
+++ b/src/Yesod/Worker/Types.hs
@@ -4,6 +4,7 @@ import Control.Concurrent (MVar)
 import Database.Redis     (Connection)
 import Keenser            (Manager)
 import Yesod              (Yesod)
+import Yesod.Core         (WidgetT, HandlerT, Html, defaultLayout)
 
 data Workers = Workers
   { wManager :: MVar Manager
@@ -12,3 +13,7 @@ data Workers = Workers
 
 class Yesod master => YesodWorker master where
   workers :: master -> Workers
+
+  workerLayout :: WidgetT master IO () -> HandlerT master IO Html
+  workerLayout = defaultLayout
+

--- a/yesod-worker.cabal
+++ b/yesod-worker.cabal
@@ -28,6 +28,7 @@ library
                      , keenser
                      , thyme
                      , yesod
+                     , yesod-core
   default-language:    Haskell2010
 
 -- executable yesod-worker-exe


### PR DESCRIPTION
 - Export a reference to the worker site route so that sites can link to it.
 - Allow sites to override the layout of the worker site.
